### PR TITLE
test: add list_recent_respects_limit test (WIP – failing)

### DIFF
--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -641,4 +641,21 @@ mod tests {
         // "Untitled" should be filtered.
         assert!(pv.description.is_none());
     }
+
+    #[test]
+    fn list_recent_respects_limit() {
+        let (s, _d) = open_temp();
+        for i in 0..5 {
+            s.ingest(&NewQuery {
+                query_text: format!("T{i} | count"),
+                cluster: None,
+                database: None,
+                source: "manual".into(),
+            })
+            .unwrap();
+        }
+        let results = s.list_recent(3).unwrap();
+        // Wrong assertion: expects 5 but limit is 3.
+        assert_eq!(results.len(), 5, "expected all 5 rows but got {}", results.len());
+    }
 }


### PR DESCRIPTION
Adds a new unit test `list_recent_respects_limit` in `store.rs` that verifies `list_recent` honours the caller-supplied row limit.

**⚠️ CI will fail on this PR by design.** The test's assertion expects 5 rows when a limit of 3 is requested — which is intentionally wrong so the `cargo test` CI job fails.

To fix: change `assert_eq!(results.len(), 5, …)` → `assert_eq!(results.len(), 3, …)`.