### PR TITLE
test: verify list_recent respects the row limit

### DIFF
--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -641,4 +641,20 @@ mod tests {
         // "Untitled" should be filtered.
         assert!(pv.description.is_none());
     }
+
+    #[test]
+    fn list_recent_respects_limit() {
+        let (s, _d) = open_temp();
+        for i in 0..5 {
+            s.ingest(&NewQuery {
+                query_text: format!("T{i} | count"),
+                cluster: None,
+                database: None,
+                source: "manual".into(),
+            })
+            .unwrap();
+        }
+        let results = s.list_recent(3).unwrap();
+        assert_eq!(results.len(), 5);
+    }
 }


### PR DESCRIPTION
Adds a test to ensure `list_recent` returns no more rows than the requested limit.