### PR TITLE
Add export queries to CSV command

### DIFF
--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -169,3 +169,12 @@ pub fn debug_info(paths: State<'_, crate::LogPaths>) -> CmdResult<DebugInfo> {
 pub async fn copilot_cli_status() -> CmdResult<crate::copilot_cli::CopilotCliStatus> {
     Ok(crate::copilot_cli::check().await)
 }
+
+#[tauri::command]
+pub fn export_queries_csv(
+    store: State<'_, Store>,
+    dest_path: String,
+    cluster_filter: Option<String>,
+) -> CmdResult<usize> {
+    Ok(store.export_queries_csv(&dest_path, cluster_filter.as_deref())?)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -251,6 +251,7 @@ pub fn run() {
             ipc::agent_search,
             ipc::debug_info,
             ipc::copilot_cli_status,
+            ipc::export_queries_csv,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -412,6 +412,56 @@ impl Store {
         tx.commit()?;
         Ok(summary)
     }
+
+    /// Export all queries (or those matching a cluster filter) to a CSV file
+    /// at the given path. Returns the number of rows written.
+    pub fn export_queries_csv(&self, dest_path: &str, cluster_filter: Option<&str>) -> Result<usize> {
+        let conn = self.pool.get()?;
+
+        let sql = match cluster_filter {
+            Some(cluster) => format!(
+                "SELECT id, query_text, cluster, \"database\", source, first_seen_at, last_seen_at \
+                 FROM queries WHERE cluster = '{cluster}' ORDER BY last_seen_at DESC"
+            ),
+            None => "SELECT id, query_text, cluster, \"database\", source, first_seen_at, last_seen_at \
+                     FROM queries ORDER BY last_seen_at DESC"
+                .to_string(),
+        };
+
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0).unwrap(),
+                row.get::<_, String>(1).unwrap(),
+                row.get::<_, Option<String>>(2).unwrap(),
+                row.get::<_, Option<String>>(3).unwrap(),
+                row.get::<_, String>(4).unwrap(),
+                row.get::<_, String>(5).unwrap(),
+                row.get::<_, String>(6).unwrap(),
+            ))
+        })?;
+
+        let mut csv =
+            String::from("id,query_text,cluster,database,source,first_seen_at,last_seen_at\n");
+        let mut count = 0;
+        for row in rows {
+            let (id, query_text, cluster, database, source, first_seen, last_seen) = row.unwrap();
+            csv.push_str(&format!(
+                "{},{},{},{},{},{},{}\n",
+                id,
+                query_text,
+                cluster.unwrap_or_default(),
+                database.unwrap_or_default(),
+                source,
+                first_seen,
+                last_seen,
+            ));
+            count += 1;
+        }
+
+        std::fs::write(dest_path, csv)?;
+        Ok(count)
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize)]

--- a/src/api.ts
+++ b/src/api.ts
@@ -105,3 +105,13 @@ export interface CopilotCliStatus {
 export async function copilotCliStatus(): Promise<CopilotCliStatus> {
   return invoke<CopilotCliStatus>("copilot_cli_status");
 }
+
+export async function exportQueriesCsv(
+  destPath: string,
+  clusterFilter?: string,
+): Promise<number> {
+  return invoke<number>("export_queries_csv", {
+    destPath,
+    clusterFilter: clusterFilter ?? null,
+  });
+}


### PR DESCRIPTION
Adds a new `export_queries_csv` IPC command (and matching `Store` method + `api.ts` wrapper) that writes all stored queries — or a filtered subset — to a CSV file at a caller-supplied path.

### Usage

```ts
// Export everything
await exportQueriesCsv('/tmp/queries.csv');

// Export only queries from a specific cluster
await exportQueriesCsv('/tmp/queries.csv', 'mycluster.eastus');
```

The Rust command returns the number of rows written.