### PR TITLE
Shorten ADX copy button label to "Copy ADX URL"

### DIFF
--- a/src/components/QueryDetail.tsx
+++ b/src/components/QueryDetail.tsx
@@ -171,7 +171,7 @@ export function QueryDetail({ query, onUpdate, onDelete }: Props) {
                 : "Cluster and database are required to build an Azure Data Explorer URL"
             }
           >
-            Copy Azure Data Explorer URL
+            Copy ADX URL
           </button>
         </div>
       </div>


### PR DESCRIPTION
The previous label "Copy Azure Data Explorer URL" was too long for the button and wrapped on smaller window widths. "Copy ADX URL" conveys the same meaning in a much more compact form.